### PR TITLE
Fix terraform Syntax & Update terraform-null-label module

### DIFF
--- a/all.tf
+++ b/all.tf
@@ -77,24 +77,24 @@ data "aws_iam_policy_document" "all" {
 
 module "all_label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.16/master"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  attributes = ["${compact(concat(var.attributes, list("all")))}"]
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  attributes = [compact(concat(var.attributes, list("all")))]
 }
 
 locals {
-  all_count = "${contains(split(",", lower(join(",", var.integrations))), "all") ? 1 : 0}"
+  all_count = contains(split(",", lower(join(",", var.integrations))), "all") ? 1 : 0
 }
 
 resource "aws_iam_policy" "all" {
-  count  = "${local.all_count}"
-  name   = "${module.all_label.id}"
-  policy = "${data.aws_iam_policy_document.all.json}"
+  count  = local.all_count
+  name   = module.all_label.id
+  policy = data.aws_iam_policy_document.all.json
 }
 
 resource "aws_iam_role_policy_attachment" "all" {
-  count      = "${local.all_count}"
-  role       = "${aws_iam_role.default.name}"
-  policy_arn = "${join("", aws_iam_policy.all.*.arn)}"
+  count      = local.all_count
+  role       = aws_iam_role.default.name
+  policy_arn = join("", aws_iam_policy.all.*.arn)
 }

--- a/all.tf
+++ b/all.tf
@@ -76,7 +76,7 @@ data "aws_iam_policy_document" "all" {
 }
 
 module "all_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.6.2"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.16/master"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"

--- a/core.tf
+++ b/core.tf
@@ -19,24 +19,24 @@ data "aws_iam_policy_document" "core" {
 
 module "core_label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.16/master"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  attributes = ["${compact(concat(var.attributes, list("core")))}"]
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  attributes = [compact(concat(var.attributes, list("core")))]
 }
 
 locals {
-  core_count = "${contains(split(",", lower(join(",", var.integrations))), "core") ? 1 : 0}"
+  core_count = contains(split(",", lower(join(",", var.integrations))), "core") ? 1 : 0
 }
 
 resource "aws_iam_policy" "core" {
-  count  = "${local.core_count}"
-  name   = "${module.core_label.id}"
-  policy = "${data.aws_iam_policy_document.core.json}"
+  count  = local.core_count
+  name   = module.core_label.id
+  policy = data.aws_iam_policy_document.core.json
 }
 
 resource "aws_iam_role_policy_attachment" "core" {
-  count      = "${local.core_count}"
-  role       = "${aws_iam_role.default.name}"
-  policy_arn = "${join("", aws_iam_policy.core.*.arn)}"
+  count      = local.core_count
+  role       = aws_iam_role.default.name
+  policy_arn = join("", aws_iam_policy.core.*.arn)
 }

--- a/core.tf
+++ b/core.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "core" {
 }
 
 module "core_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.6.2"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.16/master"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"

--- a/lambda.tf
+++ b/lambda.tf
@@ -17,24 +17,24 @@ data "aws_iam_policy_document" "lambda" {
 
 module "lambda_label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.16/master"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  attributes = ["${compact(concat(var.attributes, list("lambda")))}"]
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  attributes = [compact(concat(var.attributes, list("lambda")))]
 }
 
 locals {
-  lambda_count = "${contains(split(",", lower(join(",", var.integrations))), "lambda") ? 1 : 0}"
+  lambda_count = contains(split(",", lower(join(",", var.integrations))), "lambda") ? 1 : 0
 }
 
 resource "aws_iam_policy" "lambda" {
-  count  = "${local.lambda_count}"
-  name   = "${module.lambda_label.id}"
-  policy = "${data.aws_iam_policy_document.lambda.json}"
+  count  = local.lambda_count
+  name   = module.lambda_label.id
+  policy = data.aws_iam_policy_document.lambda.json
 }
 
 resource "aws_iam_role_policy_attachment" "lambda" {
-  count      = "${local.lambda_count}"
-  role       = "${aws_iam_role.default.name}"
-  policy_arn = "${join("", aws_iam_policy.lambda.*.arn)}"
+  count      = local.lambda_count
+  role       = aws_iam_role.default.name
+  policy_arn = join("", aws_iam_policy.lambda.*.arn)
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "lambda" {
 }
 
 module "lambda_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.6.2"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.16/master"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "trust_relationship" {
 }
 
 module "role_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.6.2"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.16/master"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 data "aws_iam_policy_document" "trust_relationship" {
-  "statement" {
+  statement {
     sid     = "DatadogAWSTrustRelationship"
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "trust_relationship" {
 
     condition {
       test     = "StringEquals"
-      values   = ["${var.datadog_external_id}"]
+      values   = [var.datadog_external_id]
       variable = "sts:ExternalId"
     }
   }
@@ -22,13 +22,13 @@ data "aws_iam_policy_document" "trust_relationship" {
 
 module "role_label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.16/master"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  attributes = ["${var.attributes}"]
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  attributes = [var.attributes]
 }
 
 resource "aws_iam_role" "default" {
-  name               = "${module.role_label.id}"
-  assume_role_policy = "${data.aws_iam_policy_document.trust_relationship.json}"
+  name               = module.role_label.id
+  assume_role_policy = data.aws_iam_policy_document.trust_relationship.json
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "role" {
-  value       = "${aws_iam_role.default.name}"
+  value       = aws_iam_role.default.name
   description = "Name of the AWS IAM Role for Datadog to use for this integration"
 }

--- a/rds.tf
+++ b/rds.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "rds" {
 }
 
 module "rds_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.6.2"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.16/master"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"

--- a/rds.tf
+++ b/rds.tf
@@ -26,24 +26,24 @@ data "aws_iam_policy_document" "rds" {
 
 module "rds_label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.16/master"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  attributes = ["${compact(concat(var.attributes, list("rds")))}"]
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  attributes = [compact(concat(var.attributes, list("rds")))]
 }
 
 locals {
-  rds_count = "${contains(split(",", lower(join(",", var.integrations))), "rds") ? 1 : 0}"
+  rds_count = contains(split(",", lower(join(",", var.integrations))), "rds") ? 1 : 0
 }
 
 resource "aws_iam_policy" "rds" {
-  count  = "${local.rds_count}"
-  name   = "${module.rds_label.id}"
-  policy = "${data.aws_iam_policy_document.rds.json}"
+  count  = local.rds_count
+  name   = module.rds_label.id
+  policy = data.aws_iam_policy_document.rds.json
 }
 
 resource "aws_iam_role_policy_attachment" "rds" {
-  count      = "${local.rds_count}"
-  role       = "${aws_iam_role.default.name}"
-  policy_arn = "${join("", aws_iam_policy.rds.*.arn)}"
+  count      = local.rds_count
+  role       = aws_iam_role.default.name
+  policy_arn = join("", aws_iam_policy.rds.*.arn)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,32 +1,37 @@
 variable "name" {
+  type        = string
   description = "The Name of the application or solution  (e.g. `bastion` or `portal`)"
   default     = "datadog"
 }
 
 variable "namespace" {
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list
   default     = []
   description = "Additional attributes (e.g. `1`)"
 }
 
 variable "datadog_external_id" {
+  type        = string
   description = "AWS External ID for this Datadog integration"
 }
 
 variable "datadog_aws_account_id" {
+  type        = string
   description = "The AWS account ID Datadog's integration servers use for all integrations"
   default     = "464622532012"
 }
 
 variable "integrations" {
-  type        = "list"
+  type        = list
   description = "List of AWS permission names to apply for different integrations (`all`, `core`, `rds`)"
 }


### PR DESCRIPTION
The `terraform-null-label` module was outdate in this repo, so this PR bumps it's version to `0.16/master` and updates the Terraform syntax.