### PR TITLE
Add `*_collection_enabled` attributes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,9 @@ resource "datadog_integration_aws" "integration" {
   host_tags                        = var.host_tags
   excluded_regions                 = var.excluded_regions
   account_specific_namespace_rules = var.account_specific_namespace_rules
+  cspm_resource_collection_enabled = var.cspm_resource_collection_enabled
+  metrics_collection_enabled       = var.metrics_collection_enabled
+  resource_collection_enabled      = var.resource_collection_enabled
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -63,7 +66,7 @@ resource "aws_iam_role" "default" {
 
 # https://docs.datadoghq.com/integrations/amazon_web_services/?tab=roledelegation#resource-collection
 resource "aws_iam_role_policy_attachment" "security_audit" {
-  count      = local.enabled && var.security_audit_policy_enabled ? 1 : 0
+  count      = local.enabled && (datadog_integration_aws.integration[0].cspm_resource_collection_enabled || var.security_audit_policy_enabled) ? 1 : 0
   role       = join("", aws_iam_role.default.*.name)
   policy_arn = format("arn:%s:iam::aws:policy/SecurityAudit", local.aws_partition)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,5 +36,23 @@ variable "account_specific_namespace_rules" {
 variable "security_audit_policy_enabled" {
   type        = bool
   default     = false
-  description = "Enable/disable attaching the AWS managed `SecurityAudit` policy to the Datadog IAM role to collect information about how AWS resources are configured (used in Datadog Cloud Security Posture Management to read security configuration metadata)"
+  description = "Enable/disable attaching the AWS managed `SecurityAudit` policy to the Datadog IAM role to collect information about how AWS resources are configured (used in Datadog Cloud Security Posture Management to read security configuration metadata). If var.cspm_resource_collection_enabled, this is enabled automatically."
+}
+
+variable "cspm_resource_collection_enabled" {
+  type = bool
+  default = false
+  description = "Whether Datadog collects cloud security posture management resources from your AWS account."
+}
+
+variable "metrics_collection_enabled" {
+  type = bool
+  default = false
+  description = "Whether Datadog collects metrics for this AWS account."
+}
+
+variable "resource_collection_enabled" {
+  type = bool
+  default = false
+  description = "Whether Datadog collects a standard set of resources from your AWS account."
 }


### PR DESCRIPTION
## What
* The Datadog AWS integration supports toggling metrics, resource, and CSPM (Cloud Security Posture Management) collection for each account. This enables setting those attributes.
* When CSPM collection is enabled, this automatically attaches the required `SecurityAudit` policy to the role.

## Why

* Allows CSPM to be declaratively enabled for AWS accounts.
* Allows metrics to be disabled for accounts.
* Retains backward compatibility by preserving `var.security_audit_policy_enabled`. In a breaking release, this could be removed in favor of just `var.cspm_resource_collection_enabled`.

## References
* https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/integration_aws#cspm_resource_collection_enabled