### PR TITLE
require datadog provider >= 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,14 +158,14 @@ Available targets:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.9 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.0 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.9 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-datadog-integration&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-datadog-integration&utm_content=website
@@ -430,3 +430,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-datadog-integration
   [share_email]: mailto:?subject=terraform-aws-datadog-integration&body=https://github.com/cloudposse/terraform-aws-datadog-integration
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-datadog-integration?pixel&cs=github&cm=readme&an=terraform-aws-datadog-integration
+<!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,14 +5,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.9 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.0 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.9 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0"
+      version = ">= 3.9"
     }
   }
 }


### PR DESCRIPTION
## What
* Requires version [`3.9.0`](https://github.com/DataDog/terraform-provider-datadog/blob/master/CHANGELOG.md#390-march-9-2022) or greater of the Datadog provider

## Why
* #42 implicitly requires this by setting attributes that were only introduced in 3.9.0. This explicitly sets that requirement earlier on, causing configurations using older versions to fail at `terraform init` rather than encounter "unexpected attribute" errors at runtime.

## References
* #42 added the new attributes 

