### PR TITLE
Update IAM policy by add support for undocumented support for WAF and…

### DIFF
--- a/iam_policy_all.tf
+++ b/iam_policy_all.tf
@@ -91,6 +91,10 @@ data "aws_iam_policy_document" "all" {
       "tag:GetResources",
       "tag:GetTagKeys",
       "tag:GetTagValues",
+      "waf:Get*",
+      "waf:List*",
+      "wafv2:Get*",
+      "wafv2:List*",
       "xray:BatchGetTraces",
       "xray:GetTraceSummaries"
     ]


### PR DESCRIPTION
Update IAM policy by add support for undocumented support for WAF and WAFv2

## what
* Add undocumented support for WAF and WAFv2 metrics

## why
* I am currently using an old, forked version of this module. While cleaning it up, it turned out that the only change it doesn't have is precisely the lack of support for WAF and WAFv2.
* I am monitoring only the metrics for WAFv2, however I think that surely someone might use old API for WAF, so I decide to add it as well


## references
* As I said, the permissions are undocumented and it is not visible here https://docs.datadoghq.com/integrations/amazon_web_services/?tab=roledelegation#aws-iam-permissions. 
* In the Datadog documentation we can find a confirmation that integration with WAF is provided - https://docs.datadoghq.com/integrations/amazon_waf/

