### PR TITLE
Add mission action to iam policy all

### DIFF
--- a/iam_policy_all.tf
+++ b/iam_policy_all.tf
@@ -26,6 +26,8 @@ data "aws_iam_policy_document" "all" {
       "dynamodb:List*",
       "dynamodb:Describe*",
       "ec2:Describe*",
+      "ec2:GetTransitGatewayPrefixListReferences",
+      "ec2:SearchTransitGatewayRoutes",
       "ecs:Describe*",
       "ecs:List*",
       "elasticache:Describe*",


### PR DESCRIPTION
## what
add
* ec2:GetTransitGatewayPrefixListReferences
* ec2:SearchTransitGatewayRoutes actions to iam policy all.

## why
We see error messages in datadog that this is not allowed for datadog-integration.