### PR TITLE
feat!: move to new AWS integration

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -66,6 +66,26 @@ usage: |-
 
   ### Migration Guide
 
+  #### Technical Details (BREAKING CHANGE v2.0.0 -> v3.0.0)
+
+  The module has been refactored to use `datadog_integration_aws_account` instead of the deprecated `datadog_integration_aws` resource. This architectural change affects all previous module versions and requires resource recreation.
+
+  #### Migration Impact
+
+  - Resource Replacement: The existing integration will be destroyed and recreated
+  - State Changes: Terraform will detect and handle state transitions
+  - Configuration Migration: Input variables are mapped to new resource schema
+
+  #### Compatibility Notes
+
+  - All existing configurations will be remapped to the new resource structure
+  - Input variables maintain backward compatibility through internal mapping
+  - State refresh will be required during upgrade
+
+  **Review Terraform plan outputs carefully before applying**
+
+  #### Migrating from v1.3.0 -> v2.0.0
+
   To migrate from the `v1.3.0` configuration, replace `var.integrations` with `var.policies` in your module usage. The values `"core"` and `"all"` previously used in `var.integrations` should be updated to `"core-integration"` and `"full-integration"`, respectively. If you were using `"CSPM"`, it now serves as an alias for `"SecurityAudit"`. Existing configurations will remain functional due to backward compatibility mappings, but updating to the new `var.policies` variable ensures alignment with the latest module structure and Datadog's documentation.
 
   ### Installation

--- a/iam-policy-core-integration.tf
+++ b/iam-policy-core-integration.tf
@@ -41,6 +41,7 @@ resource "aws_iam_policy" "core" {
   count  = local.core_count
   name   = module.core_label.id
   policy = join("", data.aws_iam_policy_document.core[*].json)
+  path   = var.policy_path
   tags   = module.core_label.tags
 }
 

--- a/iam-policy-full-integration.tf
+++ b/iam-policy-full-integration.tf
@@ -118,6 +118,7 @@ resource "aws_iam_policy" "full_integration" {
   count  = local.full_integration_count
   name   = module.full_integration_label.id
   policy = join("", data.aws_iam_policy_document.full_integration[*].json)
+  path   = var.policy_path
   tags   = module.full_integration_label.tags
 }
 

--- a/iam-policy-resource-collection.tf
+++ b/iam-policy-resource-collection.tf
@@ -50,6 +50,7 @@ resource "aws_iam_policy" "resource_collection" {
   count  = local.resource_collection_count
   name   = module.resource_collection_label.id
   policy = join("", data.aws_iam_policy_document.resource_collection[*].json)
+  path   = var.policy_path
   tags   = module.resource_collection_label.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -18,19 +18,56 @@ data "aws_caller_identity" "current" {
 }
 
 # https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/integration_aws
+resource "datadog_integration_aws_external_id" "default" {
+  count = local.enabled ? 1 : 0
+}
+
+# https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/integration_aws
 # https://docs.datadoghq.com/api/v1/aws-integration/
-resource "datadog_integration_aws" "integration" {
-  count                                = local.enabled ? 1 : 0
-  account_id                           = local.aws_account_id
-  role_name                            = module.this.id
-  filter_tags                          = var.filter_tags
-  host_tags                            = var.host_tags
-  excluded_regions                     = var.excluded_regions
-  account_specific_namespace_rules     = var.account_specific_namespace_rules
-  cspm_resource_collection_enabled     = var.cspm_resource_collection_enabled
-  metrics_collection_enabled           = var.metrics_collection_enabled
-  resource_collection_enabled          = var.resource_collection_enabled
-  extended_resource_collection_enabled = var.extended_resource_collection_enabled
+resource "datadog_integration_aws_account" "integration" {
+  count          = local.enabled ? 1 : 0
+  aws_account_id = local.aws_account_id
+  aws_partition  = local.aws_partition
+  account_tags   = var.host_tags
+  aws_regions {
+    include_all = true
+  }
+  auth_config {
+    aws_auth_config_role {
+      # If role path is set to "/", the role name will be the same as the module name
+      # If role path is set to something else, the role name will be the path + module name
+      role_name   = (var.role_path == "/") ? module.this.id : "${var.role_path}${module.this.id}"
+      external_id = local.datadog_external_id
+    }
+  }
+  logs_config {
+    lambda_forwarder {}
+  }
+  metrics_config {
+    automute_enabled          = var.automute_enabled
+    collect_cloudwatch_alarms = var.cloudwatch_alarms_enabled
+    collect_custom_metrics    = var.custom_metric_enabled
+    enabled                   = var.metrics_collection_enabled
+    namespace_filters {
+      include_only = var.namespaces
+    }
+    dynamic "tag_filters" {
+      for_each = var.tag_filters
+      content {
+        namespace = tag_filters.value.key
+        tags      = tag_filters.value.value
+      }
+    }
+  }
+  resources_config {
+    cloud_security_posture_management_collection = var.cspm_resource_collection_enabled
+    extended_collection                          = var.extended_resource_collection_enabled
+  }
+  traces_config {
+    xray_services {
+      include_only = var.xray_services
+    }
+  }
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -63,9 +100,11 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "default" {
-  count              = local.enabled ? 1 : 0
-  name               = module.this.id
-  assume_role_policy = join("", data.aws_iam_policy_document.assume_role[*].json)
-  tags               = module.this.tags
+  count                = local.enabled ? 1 : 0
+  name                 = module.this.id
+  assume_role_policy   = join("", data.aws_iam_policy_document.assume_role[*].json)
+  tags                 = module.this.tags
+  path                 = var.role_path
+  permissions_boundary = var.role_permissions_boundary
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -71,3 +71,62 @@ variable "extended_resource_collection_enabled" {
   description = "Whether Datadog collects additional attributes and configuration information about the resources in your AWS account. Required for `cspm_resource_collection_enabled`."
   default     = null
 }
+
+variable "namespaces" {
+  type        = list(string)
+  description = "An array of AWS namespaces to include in metrics collection"
+  default     = null
+}
+
+variable "tag_filters" {
+  type = list(object({
+    key   = string
+    value = string
+  }))
+  description = "An array of tag filters to apply to the metrics collection"
+  default     = []
+}
+
+variable "xray_services" {
+  type        = list(string)
+  description = "An array of AWS X-Ray services to include in metrics collection"
+  default     = null
+}
+
+variable "custom_metric_enabled" {
+  type        = bool
+  description = "Whether Datadog collects custom metrics for this AWS account."
+  default     = null
+}
+
+variable "cloudwatch_alarms_enabled" {
+  type        = bool
+  description = "Whether Datadog collects CloudWatch alarms for this AWS account."
+  default     = null
+}
+
+variable "automute_enabled" {
+  type        = bool
+  description = "Whether Datadog automutes CloudWatch alarms for this AWS account."
+  default     = null
+}
+
+variable "role_path" {
+  type        = string
+  description = "The path to the IAM role"
+  default     = "/"
+}
+
+variable "role_permissions_boundary" {
+  type        = string
+  description = "The ARN of the permissions boundary to use for the IAM role"
+  default     = null
+
+}
+
+variable "policy_path" {
+  type        = string
+  description = "The path to the IAM policy"
+  default     = "/"
+
+}


### PR DESCRIPTION
# Why
* Datadog has deprecated the old `datadog_Integration_aws` resource [Migrate to using datadog_integration_aws_account #70](https://github.com/cloudposse/terraform-aws-datadog-integration/issues/70)
* Add more flexibility to aws role creations
 
## What
* Replace deprecated `datadog_integration_aws` resource with `datadog_integration_aws_account` resource
* Add role prefixes option
* Add role permission boundary option
 
This PR is a breaking change.

## References
* Deprecation notice: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/integration_aws
* Original PR: https://github.com/cloudposse/terraform-aws-datadog-integration/pull/71

